### PR TITLE
100 Character Length Bugfix

### DIFF
--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,8 +39,10 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	log.Println(truncateString(*name, 10))
-
+	log.Println(name)
+	name = truncateString(*name, 10))
+	log.Println(name)
+	
 	pd := &PRTGEvent{
 		Probe:       *probe,
 		Device:      *device,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,7 +39,6 @@ func main() {
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	var truncatelength = flag.Int("truncatelength", 99, "The length that all inputs should be truncated to to prevent PagerDuty errors.")
-
 	flag.Parse()
 
 	*probe = truncateString(*probe, *truncatelength)

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -95,23 +95,20 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 	if err != nil {
 		t = time.Now()
 	}
-
-
-
 	newEvent := &event.Event{
-		RoutingKey: prtg.ServiceKey,
+		RoutingKey: truncateString(prtg.ServiceKey, 100),
 		Action:     "trigger",
-		DedupKey:   prtg.IncidentKey,
-		Client:     "PRTG Link",
-		ClientURL:  prtg.Link,
+		DedupKey:   truncateString(prtg.IncidentKey, 100),
+		Client:     "PRTG",
+		ClientURL:  truncateString(prtg.Link, 100),
 		Payload: &event.Payload{
-			Summary:   prtg.IncidentKey,
+			Summary:   truncateString(prtg.IncidentKey, 255),
 			Timestamp: t.Format(layout),
-			Source:    prtg.Link,
+			Source:    truncateString(prtg.Link, 100),
 			Severity:  translatePriority(prtg.Priority),
-			Component: prtg.Device,
-			Group:     prtg.Probe,
-			Class:     prtg.Name,
+			Component: truncateString(prtg.Device, 100),
+			Group:     truncateString(prtg.Probe, 100),
+			Class:     truncateString(prtg.Name, 100),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,9 +39,9 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	log.Println(name)
+	log.Println(*name)
 	*name = truncateString(*name, 10)
-	log.Println(name)
+	log.Println(*name)
 	
 	pd := &PRTGEvent{
 		Probe:       *probe,
@@ -86,6 +86,9 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 	if err != nil {
 		t = time.Now()
 	}
+
+
+
 	newEvent := &event.Event{
 		RoutingKey: prtg.ServiceKey,
 		Action:     "trigger",

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,7 +39,7 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	var name = truncateString(name, 10)
+	name = truncateString(name, 10)
 
 	pd := &PRTGEvent{
 		Probe:       *probe,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -41,17 +41,17 @@ func main() {
 
 	flag.Parse()
 
-	*probe = truncateString(*probe, truncatelength)
-	*device = truncateString(*device, truncatelength)
-	*name = truncateString(*name, truncatelength)
-	*status = truncateString(*status, truncatelength)
-	*date = truncateString(*date, truncatelength)
-	*link = truncateString(*link, truncatelength)
-	*message = truncateString(*message, truncatelength)
-	*serviceKey = truncateString(*serviceKey, truncatelength)
-	*severity = truncateString(*severity, truncatelength)
-	*priority = truncateString(*priority, truncatelength)
-	*custrouting = truncateString(*custrouting, truncatelength)
+	*probe = truncateString(*probe, *truncatelength)
+	*device = truncateString(*device, *truncatelength)
+	*name = truncateString(*name, *truncatelength)
+	*status = truncateString(*status, *truncatelength)
+	*date = truncateString(*date, *truncatelength)
+	*link = truncateString(*link, *truncatelength)
+	*message = truncateString(*message, *truncatelength)
+	*serviceKey = truncateString(*serviceKey, *truncatelength)
+	*severity = truncateString(*severity, *truncatelength)
+	*priority = truncateString(*priority, *truncatelength)
+	*custrouting = truncateString(*custrouting, *truncatelength)
 	
 	pd := &PRTGEvent{
 		Probe:       *probe,
@@ -97,19 +97,19 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		t = time.Now()
 	}
 	newEvent := &event.Event{
-		RoutingKey: truncateString(prtg.ServiceKey, truncatelength),
+		RoutingKey: truncateString(prtg.ServiceKey, *truncatelength),
 		Action:     "trigger",
-		DedupKey:   truncateString(prtg.IncidentKey, truncatelength),
+		DedupKey:   truncateString(prtg.IncidentKey, *truncatelength),
 		Client:     "PRTG",
-		ClientURL:  truncateString(prtg.Link, truncatelength),
+		ClientURL:  truncateString(prtg.Link, *truncatelength),
 		Payload: &event.Payload{
 			Summary:   truncateString(prtg.IncidentKey, 254),
 			Timestamp: t.Format(layout),
-			Source:    truncateString(prtg.Link, truncatelength),
+			Source:    truncateString(prtg.Link, *truncatelength),
 			Severity:  translatePriority(prtg.Priority),
-			Component: truncateString(prtg.Device, truncatelength),
-			Group:     truncateString(prtg.Probe, truncatelength),
-			Class:     truncateString(prtg.Name, truncatelength),
+			Component: truncateString(prtg.Device, *truncatelength),
+			Group:     truncateString(prtg.Probe, *truncatelength),
+			Class:     truncateString(prtg.Name, *truncatelength),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/ccummings-coeur/prtg-pagerduty/event"
+	"github.com/coeurmining/prtg-pagerduty/event"
 	"log"
 	"strings"
 	"time"
@@ -39,6 +39,8 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
+	var name = truncateString(name, 10)
+
 	pd := &PRTGEvent{
 		Probe:       *probe,
 		Device:      *device,
@@ -63,6 +65,17 @@ func main() {
 		}
 		log.Println(event)
 	}
+}
+
+func truncateString(str string, num int) string {
+	stringtotruncate := str
+	if len(str) > num {
+		if num > 3 {
+			num -= 3
+		}
+		stringtotruncate = str[0:num] + "..."
+	}
+	return stringtotruncate
 }
 
 func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,7 +39,7 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	log.Println(truncateString(name, 10))
+	log.Println(truncateString(*name, 10))
 
 	pd := &PRTGEvent{
 		Probe:       *probe,
@@ -67,7 +67,7 @@ func main() {
 	}
 }
 
-func truncateString(string, num int) string {
+func truncateString(str string, num int) string {
 	stringtotruncate := str
 	if len(str) > num {
 		if num > 3 {

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -99,19 +99,19 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		t = time.Now()
 	}
 	newEvent := &event.Event{
-		RoutingKey: truncateString(prtg.ServiceKey, *truncatelength),
+		RoutingKey: truncateString(prtg.ServiceKey, prtg.truncatelength),
 		Action:     "trigger",
-		DedupKey:   truncateString(prtg.IncidentKey, *truncatelength),
+		DedupKey:   truncateString(prtg.IncidentKey, prtg.truncatelength),
 		Client:     "PRTG",
-		ClientURL:  truncateString(prtg.Link, *truncatelength),
+		ClientURL:  truncateString(prtg.Link, prtg.truncatelength),
 		Payload: &event.Payload{
 			Summary:   truncateString(prtg.IncidentKey, 254),
 			Timestamp: t.Format(layout),
-			Source:    truncateString(prtg.Link, *truncatelength),
+			Source:    truncateString(prtg.Link, prtg.truncatelength),
 			Severity:  translatePriority(prtg.Priority),
-			Component: truncateString(prtg.Device, *truncatelength),
-			Group:     truncateString(prtg.Probe, *truncatelength),
-			Class:     truncateString(prtg.Name, *truncatelength),
+			Component: truncateString(prtg.Device, prtg.truncatelength),
+			Group:     truncateString(prtg.Probe, prtg.truncatelength),
+			Class:     truncateString(prtg.Name, prtg.truncatelength),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -37,20 +37,21 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
-	
+	var truncatelength = flag.String("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
+
 	flag.Parse()
 
-	*probe = truncateString(*probe, 100)
-	*device = truncateString(*device, 100)
-	*name = truncateString(*name, 100)
-	*status = truncateString(*status, 100)
-	*date = truncateString(*date, 100)
-	*link = truncateString(*link, 100)
-	*message = truncateString(*message, 100)
-	*serviceKey = truncateString(*serviceKey, 100)
-	*severity = truncateString(*severity, 100)
-	*priority = truncateString(*priority, 100)
-	*custrouting = truncateString(*custrouting, 100)
+	*probe = truncateString(*probe, truncatelength)
+	*device = truncateString(*device, truncatelength)
+	*name = truncateString(*name, truncatelength)
+	*status = truncateString(*status, truncatelength)
+	*date = truncateString(*date, truncatelength)
+	*link = truncateString(*link, truncatelength)
+	*message = truncateString(*message, truncatelength)
+	*serviceKey = truncateString(*serviceKey, truncatelength)
+	*severity = truncateString(*severity, truncatelength)
+	*priority = truncateString(*priority, truncatelength)
+	*custrouting = truncateString(*custrouting, truncatelength)
 	
 	pd := &PRTGEvent{
 		Probe:       *probe,
@@ -96,19 +97,19 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		t = time.Now()
 	}
 	newEvent := &event.Event{
-		RoutingKey: truncateString(prtg.ServiceKey, 100),
+		RoutingKey: truncateString(prtg.ServiceKey, truncatelength),
 		Action:     "trigger",
-		DedupKey:   truncateString(prtg.IncidentKey, 100),
+		DedupKey:   truncateString(prtg.IncidentKey, truncatelength),
 		Client:     "PRTG",
-		ClientURL:  truncateString(prtg.Link, 100),
+		ClientURL:  truncateString(prtg.Link, truncatelength),
 		Payload: &event.Payload{
-			Summary:   truncateString(prtg.IncidentKey, 255),
+			Summary:   truncateString(prtg.IncidentKey, 254),
 			Timestamp: t.Format(layout),
-			Source:    truncateString(prtg.Link, 100),
+			Source:    truncateString(prtg.Link, truncatelength),
 			Severity:  translatePriority(prtg.Priority),
-			Component: truncateString(prtg.Device, 100),
-			Group:     truncateString(prtg.Probe, 100),
-			Class:     truncateString(prtg.Name, 100),
+			Component: truncateString(prtg.Device, truncatelength),
+			Group:     truncateString(prtg.Probe, truncatelength),
+			Class:     truncateString(prtg.Name, truncatelength),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -99,19 +99,19 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		t = time.Now()
 	}
 	newEvent := &event.Event{
-		RoutingKey: truncateString(prtg.ServiceKey, prtg.truncatelength),
+		RoutingKey: truncateString(prtg.ServiceKey, prtg.TruncateLength),
 		Action:     "trigger",
-		DedupKey:   truncateString(prtg.IncidentKey, prtg.truncatelength),
+		DedupKey:   truncateString(prtg.IncidentKey, prtg.TruncateLength),
 		Client:     "PRTG",
-		ClientURL:  truncateString(prtg.Link, prtg.truncatelength),
+		ClientURL:  truncateString(prtg.Link, prtg.TruncateLength),
 		Payload: &event.Payload{
 			Summary:   truncateString(prtg.IncidentKey, 254),
 			Timestamp: t.Format(layout),
-			Source:    truncateString(prtg.Link, prtg.truncatelength),
+			Source:    truncateString(prtg.Link, prtg.TruncateLength),
 			Severity:  translatePriority(prtg.Priority),
-			Component: truncateString(prtg.Device, prtg.truncatelength),
-			Group:     truncateString(prtg.Probe, prtg.truncatelength),
-			Class:     truncateString(prtg.Name, prtg.truncatelength),
+			Component: truncateString(prtg.Device, prtg.TruncateLength),
+			Group:     truncateString(prtg.Probe, prtg.TruncateLength),
+			Class:     truncateString(prtg.Name, prtg.TruncateLength),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -67,7 +67,7 @@ func main() {
 	}
 }
 
-func truncateString(str string, num int) string {
+func truncateString(string, num int) string {
 	stringtotruncate := str
 	if len(str) > num {
 		if num > 3 {

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -66,6 +66,7 @@ func main() {
 		Severity:    *severity,
 		Priority:    *priority,
 		CustRouting: *custrouting,
+		TruncateLength: *truncatelength,
 	}
 
 	if strings.Contains(pd.Status, "Up") || strings.Contains(pd.Status, "ended") {

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -102,7 +102,7 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		RoutingKey: prtg.ServiceKey,
 		Action:     "trigger",
 		DedupKey:   prtg.IncidentKey,
-		Client:     "PRTG: " + prtg.IncidentKey,
+		Client:     "PRTG Link",
 		ClientURL:  prtg.Link,
 		Payload: &event.Payload{
 			Summary:   prtg.IncidentKey,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -41,17 +41,17 @@ func main() {
 
 	flag.Parse()
 
-	*probe = truncateString(*probe, *truncatelength)
-	*device = truncateString(*device, *truncatelength)
-	*name = truncateString(*name, *truncatelength)
-	*status = truncateString(*status, *truncatelength)
-	*date = truncateString(*date, *truncatelength)
-	*link = truncateString(*link, *truncatelength)
-	*message = truncateString(*message, *truncatelength)
-	*serviceKey = truncateString(*serviceKey, *truncatelength)
-	*severity = truncateString(*severity, *truncatelength)
-	*priority = truncateString(*priority, *truncatelength)
-	*custrouting = truncateString(*custrouting, *truncatelength)
+	*probe = truncateString(*probe, truncatelength)
+	*device = truncateString(*device, truncatelength)
+	*name = truncateString(*name, truncatelength)
+	*status = truncateString(*status, truncatelength)
+	*date = truncateString(*date, truncatelength)
+	*link = truncateString(*link, truncatelength)
+	*message = truncateString(*message, truncatelength)
+	*serviceKey = truncateString(*serviceKey, truncatelength)
+	*severity = truncateString(*severity, truncatelength)
+	*priority = truncateString(*priority, truncatelength)
+	*custrouting = truncateString(*custrouting, truncatelength)
 	
 	pd := &PRTGEvent{
 		Probe:       *probe,
@@ -97,19 +97,19 @@ func triggerEvent(prtg *PRTGEvent) (*event.Response, error) {
 		t = time.Now()
 	}
 	newEvent := &event.Event{
-		RoutingKey: truncateString(prtg.ServiceKey, *truncatelength),
+		RoutingKey: truncateString(prtg.ServiceKey, truncatelength),
 		Action:     "trigger",
-		DedupKey:   truncateString(prtg.IncidentKey, *truncatelength),
+		DedupKey:   truncateString(prtg.IncidentKey, truncatelength),
 		Client:     "PRTG",
-		ClientURL:  truncateString(prtg.Link, *truncatelength),
+		ClientURL:  truncateString(prtg.Link, truncatelength),
 		Payload: &event.Payload{
 			Summary:   truncateString(prtg.IncidentKey, 254),
 			Timestamp: t.Format(layout),
-			Source:    truncateString(prtg.Link, *truncatelength),
+			Source:    truncateString(prtg.Link, truncatelength),
 			Severity:  translatePriority(prtg.Priority),
-			Component: truncateString(prtg.Device, *truncatelength),
-			Group:     truncateString(prtg.Probe, *truncatelength),
-			Class:     truncateString(prtg.Name, *truncatelength),
+			Component: truncateString(prtg.Device, truncatelength),
+			Group:     truncateString(prtg.Probe, truncatelength),
+			Class:     truncateString(prtg.Name, truncatelength),
 			Details: "Link: " + prtg.Link +
 				"\nIncidentKey: " + prtg.IncidentKey +
 				"\nStatus: " + prtg.Status +

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -37,6 +37,7 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
+	
 	flag.Parse()
 
 	*probe = truncateString(*probe, 100)
@@ -60,7 +61,7 @@ func main() {
 		Link:        *link,
 		Message:     *message,
 		ServiceKey:  *serviceKey,
-		IncidentKey: *probe + "-" + *device + "-" + *name,
+		IncidentKey: truncateString(*probe + "-" + *device + "-" + *name, 100),
 		Severity:    *severity,
 		Priority:    *priority,
 		CustRouting: *custrouting,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -23,7 +23,6 @@ type PRTGEvent struct {
 	Severity    string
 	Priority    string
 	CustRouting string
-	TruncateLength int
 }
 
 func main() {
@@ -38,7 +37,7 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
-	var truncatelength = flag.Int("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
+	var  truncatelength int = flag.Int("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
 
 	flag.Parse()
 

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -40,7 +40,7 @@ func main() {
 	flag.Parse()
 
 	log.Println(name)
-	name = truncateString(*name, 10)
+	*name = truncateString(*name, 10)
 	log.Println(name)
 	
 	pd := &PRTGEvent{

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -47,7 +47,6 @@ func main() {
 	*status = truncateString(*status, *truncatelength)
 	*date = truncateString(*date, *truncatelength)
 	*link = truncateString(*link, *truncatelength)
-	// *message = truncateString(*message, *truncatelength)
 	*serviceKey = truncateString(*serviceKey, *truncatelength)
 	*severity = truncateString(*severity, *truncatelength)
 	*priority = truncateString(*priority, *truncatelength)

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -23,6 +23,7 @@ type PRTGEvent struct {
 	Severity    string
 	Priority    string
 	CustRouting string
+	TruncateLength int
 }
 
 func main() {

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -48,7 +48,7 @@ func main() {
 	*status = truncateString(*status, *truncatelength)
 	*date = truncateString(*date, *truncatelength)
 	*link = truncateString(*link, *truncatelength)
-	*message = truncateString(*message, *truncatelength)
+	// *message = truncateString(*message, *truncatelength)
 	*serviceKey = truncateString(*serviceKey, *truncatelength)
 	*severity = truncateString(*severity, *truncatelength)
 	*priority = truncateString(*priority, *truncatelength)

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,7 +39,7 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	name = truncateString(name, 10)
+	log.Println(truncateString(name, 10))
 
 	pd := &PRTGEvent{
 		Probe:       *probe,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -40,7 +40,7 @@ func main() {
 	flag.Parse()
 
 	log.Println(name)
-	name = truncateString(*name, 10))
+	name = truncateString(*name, 10)
 	log.Println(name)
 	
 	pd := &PRTGEvent{

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -61,7 +61,7 @@ func main() {
 		Link:        *link,
 		Message:     *message,
 		ServiceKey:  *serviceKey,
-		IncidentKey: truncateString(*probe + "-" + *device + "-" + *name, 100),
+		IncidentKey: truncateString(*probe + "-" + *device + "-" + *name, 50),
 		Severity:    *severity,
 		Priority:    *priority,
 		CustRouting: *custrouting,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -39,9 +39,17 @@ func main() {
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
 	flag.Parse()
 
-	log.Println(*name)
-	*name = truncateString(*name, 10)
-	log.Println(*name)
+	*probe = truncateString(*probe, 100)
+	*device = truncateString(*device, 100)
+	*name = truncateString(*name, 100)
+	*status = truncateString(*status, 100)
+	*date = truncateString(*date, 100)
+	*link = truncateString(*link, 100)
+	*message = truncateString(*message, 100)
+	*serviceKey = truncateString(*serviceKey, 100)
+	*severity = truncateString(*severity, 100)
+	*priority = truncateString(*priority, 100)
+	*custrouting = truncateString(*custrouting, 100)
 	
 	pd := &PRTGEvent{
 		Probe:       *probe,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -61,7 +61,7 @@ func main() {
 		Link:        *link,
 		Message:     *message,
 		ServiceKey:  *serviceKey,
-		IncidentKey: truncateString(*probe + "-" + *device + "-" + *name, 50),
+		IncidentKey: *probe + "-" + *device + "-" + *name,
 		Severity:    *severity,
 		Priority:    *priority,
 		CustRouting: *custrouting,

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -37,7 +37,7 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
-	var truncatelength = flag.String("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
+	var truncatelength = flag.Int("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
 
 	flag.Parse()
 

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -37,7 +37,7 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
-	var truncatelength = flag.Int("truncatelength", "99", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
+	var truncatelength = flag.Int("truncatelength", 99, "The length that all inputs should be truncated to to prevent PagerDuty errors.")
 
 	flag.Parse()
 

--- a/pagerduty.go
+++ b/pagerduty.go
@@ -37,7 +37,7 @@ func main() {
 	var severity = flag.String("severity", "error", "The severity level of the incident (critical, error, warning, or info)")
 	var priority = flag.String("priority", "priority", "The Priority of the Sensor in PRTG")
 	var custrouting = flag.String("custrouting", "custrouting", "The custom routing identifier for PD Event Rules")
-	var  truncatelength int = flag.Int("truncatelength", "truncatelength", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
+	var truncatelength = flag.Int("truncatelength", "99", "The length that all inputs should be truncated to to prevent PagerDuty errors.")
 
 	flag.Parse()
 


### PR DESCRIPTION
As it turns out, PagerDuty has an undocumented 100 character limit on the "client:" JSON key. This key is not critical at all to the alerting process, as it only exists to show the name of the Integration so that it can be linked to. This has now just been hardcoded to show "PRTG" as that is the only necessary information. 

I have added a new function called "truncateString()" that (believe it or not) allows you to... truncate a string. This was added as a response to the 100 Character Length issue. Now this function is called on most strings before they go into the JSON marshaling function in event.go and get sent to PagerDuty, hopefully alleviating any length-based issues with PagerDuty

I have also added a new int flag to set how long to truncate all of the fields to (except summary and custom_details, which testing does not show any character limits on.)

We still need to come up with a method for handling errors and logging/alerting on them appropriately, but that will likely need to come in a larger re-working of this integration.
